### PR TITLE
Warn, don't fail, on browser disconnects

### DIFF
--- a/lib/runners/browser_test_runner.js
+++ b/lib/runners/browser_test_runner.js
@@ -149,11 +149,7 @@ BrowserTestRunner.prototype = {
         return;
       }
 
-      var result = {
-        failed: 1,
-        name: 'Browser ' + self.launcher.commandLine() + ' disconnected unexpectedly.'
-      };
-      self.onTestResult.call(self, result);
+      console.warn('Browser ' + self.launcher.commandLine() + ' disconnected unexpectedly.');
       self.finish();
     }, 1000);
   },


### PR DESCRIPTION
@fastly/ux These disconnects seem to happen with great frequency in CI and any time we restart the tests in development. They don't prevent the rest of the test suite from being reported correctly, nor do they prevent logs from streaming back to Testem (and thus the CI build). For now, we'll try reducing the severity from test-failure to warning.

See https://github.com/testem/testem/issues/777
